### PR TITLE
Fix type mismatch for histo

### DIFF
--- a/lib/quantize_dart.dart
+++ b/lib/quantize_dart.dart
@@ -117,7 +117,7 @@ class VBox {
   int g2;
   int b1;
   int b2;
-  Map<int, int?> histo = {};
+  List<int?> histo = [];
 
   VBox(
     this.r1,


### PR DESCRIPTION
I encountered a runtime error because of the type mismatch between Map<int, int?> and List<int?> for histo. I changed it to List<int?> and the runtime error was fixed. I used a local copy of this package along with the color_thief_flutter on my app to test this.